### PR TITLE
Add additional fields (revised_prompt, b64_json) to image response

### DIFF
--- a/src/apis/images.rs
+++ b/src/apis/images.rs
@@ -51,7 +51,9 @@ pub struct Images {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ImageData {
-	pub url: String,
+	pub url: Option<String>,
+	pub revised_prompt: Option<String>,
+	pub b64_json: Option<String>,
 }
 
 pub trait ImagesApi {


### PR DESCRIPTION
Ref:

- https://platform.openai.com/docs/api-reference/images/object
- https://github.com/openai/openai-openapi/blob/440c1718f0ea39d32d3735018cbcd6785a93db79/openapi.yaml#L10199-L10208

As per the OpenAI spec, these fields are always non-optional and always returned as a potentially-empty string.

In practice, other providers (like LocalAI) only return a `b64_json` field if `response_format = b64_json`. There's neither a `url` field, nor a `revised_prompt`.

For maximum compatibility, `url` was also made an `Option<String>`.