### PR TITLE
Added support for reasoning models

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ fn main() {
     let openai = OpenAI::new(auth, "https://api.openai.com/v1/");
     let body = ChatBody {
         model: "gpt-3.5-turbo".to_string(),
-        max_tokens: Some(7),
+        max_completion_tokens: Some(7),
         temperature: Some(0_f32),
         top_p: Some(0_f32),
         n: Some(2),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //!     let openai = OpenAI::new(auth, "https://api.openai.com/v1/");
 //!     let body = ChatBody {
 //!         model: "gpt-3.5-turbo".to_string(),
-//!         max_tokens: Some(7),
+//!         max_completion_tokens: Some(7),
 //!         temperature: Some(0_f32),
 //!         top_p: Some(0_f32),
 //!         n: Some(2),


### PR DESCRIPTION
Because reasoning models a la `o1-mini` don't return all generated tokens the variable `max_tokens `was renamed in the official API to `max_completion_tokens`. `max_tokens `is consifered deprecated for chat models but remains supported in older models and is the _only supported option_ for (non-chat) completion API.

When using reasoning models set `temperature: None, top_p: None`. The API supports only those values (and temp=1.0 which is equivalent)

**This PR**:

1. renames `max_tokens `-> `max_completion_tokens` in ChatBody to support reasoning models
2. added reasoning model test
3. deals with 0.1.9 non-compatibility with reasoning API in the narrowest way possible

**This PR is not**:

1. Backward compatible. Updating to this version requires swapping `max_tokens `-> `max_completion_tokens` in every existing use
2. providing a clear error message if you set temperature and top_p to an illegal value